### PR TITLE
bootfiles: use OE deployment mechanism properly

### DIFF
--- a/recipes-bsp/bootfiles/minnowboard-efi-startup.bb
+++ b/recipes-bsp/bootfiles/minnowboard-efi-startup.bb
@@ -5,8 +5,10 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 COMPATIBLE_MACHINE = "intel-corei7-64"
 ALLOW_EMPTY_${PN} = "1"
 
-do_install() {
-    mkdir -p ${DEPLOY_DIR_IMAGE}
-    echo 'fs0:\\EFI\\BOOT\\bootx64.efi' > ${DEPLOY_DIR_IMAGE}/startup.nsh
+inherit deploy
+
+do_deploy() {
+    echo 'fs0:\\EFI\\BOOT\\bootx64.efi' > ${DEPLOYDIR}/startup.nsh
 }
 
+addtask do_deploy


### PR DESCRIPTION
Also fixes a bug causing the recipe fail if built before DEPLOY_DIR_IMAGE is created.

BTW, @patrickvacek, normal build for Minnowboard on shovel doesn't show the build failures you're seeing in oe-selftest.