### PR TITLE
minnowboard-efi-startup: Make sure deploy dir exists.

### DIFF
--- a/recipes-bsp/bootfiles/minnowboard-efi-startup.bb
+++ b/recipes-bsp/bootfiles/minnowboard-efi-startup.bb
@@ -6,6 +6,7 @@ COMPATIBLE_MACHINE = "intel-corei7-64"
 ALLOW_EMPTY_${PN} = "1"
 
 do_install() {
+    mkdir -p ${DEPLOY_DIR_IMAGE}
     echo 'fs0:\\EFI\\BOOT\\bootx64.efi' > ${DEPLOY_DIR_IMAGE}/startup.nsh
 }
 


### PR DESCRIPTION
Otherwise it might not be there before we try to write to it. This wasn't necessary in the past but it apparently is no longer guaranteed to be present.

This fixes the bug I saw when trying to test https://github.com/advancedtelematic/meta-updater/pull/557.