### PR TITLE
layer.conf: add gatesgarth to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_updater-minnowboard = "7"
 
 LAYERDEPENDS_updater-minnowboard = "sota"
 LAYERDEPENDS_updater-minnowboard += "intel"
-LAYERSERIES_COMPAT_updater-minnowboard = "dunfell"
+LAYERSERIES_COMPAT_updater-minnowboard = "dunfell gatesgarth"


### PR DESCRIPTION
bitbake does not work for master after gatesgarth release. fix it
Signed-off-by: Anatoliy Odukha <aodukha@gmail.com>